### PR TITLE
Update DnDBeyond_extractor.js to handle tables with multiple columns

### DIFF
--- a/useful_scripts/DnDBeyond_extractor.js
+++ b/useful_scripts/DnDBeyond_extractor.js
@@ -69,6 +69,7 @@ let jsonData = {
   displayRolle: true
 };
 let rows = exportedTable.getElementsByTagName("tbody")[0].rows;
+let headings = exportedTable.getElementsByTagName("thead")[0].rows[0].cells;
 for (let i = 0; i < rows.length; i++) {
    let firstCol = rows[i].cells[0].textContent; //first column
    let range = firstCol.split("–").map(val => val == '00' ? 100 : val).map(val => parseInt(val, 10)); //range of roll results. first column
@@ -85,6 +86,7 @@ for (let i = 0; i < rows.length; i++) {
          .replace(/\n/g, '') // remove \n
          .replace(/\dd\d+/ig, match => `[[${match}]]`); // convert dice rolls.
        if (row_text !== '—'){ // cell has a dash when blank - skip
+           row_text += ' ' + headings[j].textContent + ' ' // add heading
              if (text){
                  text += ' and ' // add on if additional cell
              }

--- a/useful_scripts/DnDBeyond_extractor.js
+++ b/useful_scripts/DnDBeyond_extractor.js
@@ -12,7 +12,7 @@
  * 5. Import the downloaded file & celebrate.
  */
 
- let tableId = "e63f3dd5-6219-4218-891e-2b57741308b6"; // replace with the table id or data-content-chunk-id
+ let tableId = "579e6e59-34d9-42e9-a61e-e4fb5167290c"; // replace with the table id or data-content-chunk-id
 
 //////////////////////////////////////////////////
 // You should not need to modify anything below //
@@ -86,7 +86,7 @@ for (let i = 0; i < rows.length; i++) {
          .replace(/\n/g, '') // remove \n
          .replace(/\dd\d+/ig, match => `[[${match}]]`); // convert dice rolls.
        if (row_text !== '—'){ // cell has a dash when blank - skip
-           row_text += ' ' + headings[j].textContent + ' ' // add heading
+           row_text += ' (' + headings[j].textContent + ') ' // add heading
              if (text){
                  text += ' and ' // add on if additional cell
              }

--- a/useful_scripts/DnDBeyond_extractor.js
+++ b/useful_scripts/DnDBeyond_extractor.js
@@ -12,7 +12,7 @@
  * 5. Import the downloaded file & celebrate.
  */
 
- let tableId = "34014cfb-839f-4718-a955-a7415c55ab0b"; // replace with the table id or data-content-chunk-id
+ let tableId = "e63f3dd5-6219-4218-891e-2b57741308b6"; // replace with the table id or data-content-chunk-id
 
 //////////////////////////////////////////////////
 // You should not need to modify anything below //
@@ -79,9 +79,18 @@ for (let i = 0; i < rows.length; i++) {
    } else {
     weight = range[1] - range[0] + 1
    }
-   let text = rows[i].cells[1].textContent // second column
-     .replace(/\n/g, '') // remove \n
-     .replace(/\dd\d+/ig, match => `[[${match}]]`); // convert dice rolls.
+   let text = ''
+   for (let j = 1; j < rows[i].cells.length; j++){
+       let row_text = rows[i].cells[j].textContent // second column
+         .replace(/\n/g, '') // remove \n
+         .replace(/\dd\d+/ig, match => `[[${match}]]`); // convert dice rolls.
+       if (row_text != '—'){
+             if (text){
+                 text += ' and ' // add on if additional cell
+             };
+             text += row_text // update text for row
+         };
+   };
    jsonData.results.push({
       flags: {},
       type: 0,

--- a/useful_scripts/DnDBeyond_extractor.js
+++ b/useful_scripts/DnDBeyond_extractor.js
@@ -80,17 +80,17 @@ for (let i = 0; i < rows.length; i++) {
     weight = range[1] - range[0] + 1
    }
    let text = ''
-   for (let j = 1; j < rows[i].cells.length; j++){
-       let row_text = rows[i].cells[j].textContent // second column
+   for (let j = 1; j < rows[i].cells.length; j++){ // cycle through each cell after the 1st
+       let row_text = rows[i].cells[j].textContent
          .replace(/\n/g, '') // remove \n
          .replace(/\dd\d+/ig, match => `[[${match}]]`); // convert dice rolls.
-       if (row_text != '—'){
+       if (row_text !== '—'){ // cell has a dash when blank - skip
              if (text){
                  text += ' and ' // add on if additional cell
-             };
+             }
              text += row_text // update text for row
-         };
-   };
+         }
+   }
    jsonData.results.push({
       flags: {},
       type: 0,


### PR DESCRIPTION
I have a change here to help importing of tables with multiple columns, such as the treasure tables in the DMG at https://www.dndbeyond.com/sources/dmg/treasure#RandomTreasure

* It will treat any cell that equals — as blank
* It will include the column header in the extracted text (required for the coin tables, but may look a bit awkward elsewhere)
* If there are multiple columns it will separate each entry with the word "and"