### PR TITLE
module.json: Fix download link

### DIFF
--- a/module.json
+++ b/module.json
@@ -22,7 +22,7 @@
     ],
     "url": "https://github.com/foundry-vtt-community/tables",
     "manifest": "https://raw.githubusercontent.com/foundry-vtt-community/tables/master/module.json",
-    "download": "https://github.com/foundry-vtt-community/tables/archive/v0.6.zip",
+    "download": "https://github.com/foundry-vtt-community/tables/archive/v0.7.zip",
     "socket": true,
     "minimumCoreVersion": "0.6.2",
     "compatibleCoreVersion": "0.6.5"


### PR DESCRIPTION
This is still pointing to the v0.6 link, so the latest release is never downloaded.